### PR TITLE
Migrate from Deno Deploy Classic to the new Deno Deploy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,7 @@
 {
   "deno.enable": true,
   "deno.lint": true,
-  "deno.unstable": true,
-  "deno.config": "tsconfig.json",
+  "deno.config": "deno.json",
   "editor.defaultFormatter": "denoland.vscode-deno",
   "editor.formatOnSave": true
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # ephemeral
 
-A simple deno deploy script for temporarily hosting anything (limited to 5KiB).
+A simple Deno script for temporarily hosting anything (limited to 32KiB).
+
+## Development
+
+```sh
+deno task dev
+```
+
+This runs the server locally on http://localhost:8000 with file watching.
+
+## Deploying
+
+This app targets the new [Deno Deploy](https://console.deno.com). Either:
+
+- **GitHub integration** — connect this repository from the Deno Deploy
+  dashboard; builds run automatically on push (no GitHub Actions config needed).
+  The entrypoint (`index.tsx`) is configured in `deno.json`.
+- **CLI** — deploy with the `deno deploy` subcommand (replaces the deprecated
+  `deployctl`).

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,14 @@
+{
+  "tasks": {
+    "dev": "deno run --watch --allow-import --allow-net --allow-read --allow-env index.tsx",
+    "start": "deno run --allow-import --allow-net --allow-read --allow-env index.tsx"
+  },
+  "compilerOptions": {
+    "jsx": "react",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment"
+  },
+  "deploy": {
+    "entrypoint": "index.tsx"
+  }
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,14 @@
+{
+  "version": "5",
+  "remote": {
+    "https://deno.land/std@0.61.0/encoding/utf8.ts": "8654fa820aa69a37ec5eb11908e20b39d056c9bf1c23ab294303ff467f3d50a1",
+    "https://deno.land/x/bcrypt@v0.2.4/deps.ts": "dc2253e8aed3c5670f096fe9515913f644b650bae7212d8f6af5c14b88350461",
+    "https://deno.land/x/bcrypt@v0.2.4/mod.ts": "8eaac7e28fd305228e5994de60032b743282bfeadd5060c1759288d27f32d28e",
+    "https://deno.land/x/bcrypt@v0.2.4/src/bcrypt/base64.ts": "b8266450a4f1eb6960f60f2f7986afc4dde6b45bd2d7ee7ba10789e67e17b9f7",
+    "https://deno.land/x/bcrypt@v0.2.4/src/bcrypt/bcrypt.ts": "7845b01323458b530dcf6e9ab46e513c507b6ff1670457afaa0b3465721b56b4",
+    "https://deno.land/x/bcrypt@v0.2.4/src/main.ts": "4ac3ccc2247ce729f6c7d57654909949b62aafdabd996483c97f34aa1afac82a",
+    "https://x.lcas.dev/preact@10.5.12/hooks.js": "a2a9853ecf65c4a5b04a4b4209792663372cc3b7d054049b5fb50d4accf219e0",
+    "https://x.lcas.dev/preact@10.5.12/mod.js": "62eb264b333369c5c3f5186fc97964c1787f9352d52decfde9c50084add3a86f",
+    "https://x.lcas.dev/preact@10.5.12/ssr.js": "17b5eebfac9321092cee4a6fcbf9a88885936824eadf2c1c16b297cb829721e1"
+  }
+}

--- a/dev
+++ b/dev
@@ -1,1 +1,1 @@
-deployctl run --no-check --watch index.tsx
+deno task dev

--- a/index.tsx
+++ b/index.tsx
@@ -4,16 +4,9 @@ import { h, renderToString } from "./deps.ts";
 import { App } from "./webapp/App.tsx";
 import { statics } from "./webapp/statics.ts";
 
-const css = await fetch(
-  import.meta.url.split("/").slice(0, -1).join("/") + "/webapp/style.css"
-).then((r) => r.text());
-
-type FetchEvent = {
-  request: Request;
-  respondWith: (response: Response) => void;
-};
-
-const isFetchEvent = (event: Event | FetchEvent): event is FetchEvent => true;
+const css = await Deno.readTextFile(
+  new URL("./webapp/style.css", import.meta.url),
+);
 
 const handler = async (request: Request) => {
   const params = await parseRequest(request);
@@ -27,30 +20,34 @@ const handler = async (request: Request) => {
 
   return new Response(
     `<!DOCTYPE html>
-${renderToString(
-  <html>
-    <head>
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <style>{css}</style>
-    </head>
-    <body>
-      <App />
-    </body>
-  </html>
-)}`,
-    { headers: { "Content-Type": "text/html" } }
+${
+      renderToString(
+        <html>
+          <head>
+            <meta
+              name="viewport"
+              content="width=device-width, initial-scale=1"
+            />
+            <style>{css}</style>
+          </head>
+          <body>
+            <App />
+          </body>
+        </html>,
+      )
+    }`,
+    { headers: { "Content-Type": "text/html" } },
   );
 };
 
-addEventListener("fetch", async (event) => {
+Deno.serve(async (request) => {
   const start = Date.now();
-  if (!isFetchEvent(event)) return;
-  const response = await handler(event.request);
+  const response = await handler(request);
   console.log(
-    event.request.method,
-    event.request.url,
+    request.method,
+    request.url,
     response.status,
-    Date.now() - start + "ms"
+    Date.now() - start + "ms",
   );
-  event.respondWith(response);
+  return response;
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "compilerOptions": {
-    "jsx": "react",
-    "jsxFactory": "h",
-    "jsxFragmentFactory": "Fragment"
-  }
-}

--- a/util/BinaryHeap.ts
+++ b/util/BinaryHeap.ts
@@ -6,11 +6,11 @@ export class BinaryHeap<T> extends Array<T> {
     this.scoreFunc = scoreFunc;
   }
 
-  push(element: T): number {
+  override push(element: T): number {
     return this.bubbleUp(super.push(element) - 1);
   }
 
-  pop(): T {
+  override pop(): T {
     const top = this[0];
     const bottom = super.pop();
 
@@ -66,9 +66,10 @@ export class BinaryHeap<T> extends Array<T> {
 
         if (
           this.scoreFunc(right) <
-          (swapIndex === undefined ? score : (leftScore as number))
-        )
+            (swapIndex === undefined ? score : (leftScore as number))
+        ) {
           swapIndex = rightIndex;
+        }
       }
 
       if (swapIndex === undefined) break;

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -1,1 +1,0 @@
-export const baseUrl = import.meta.url.split("/").slice(0, -2).join("/");

--- a/webapp/statics.ts
+++ b/webapp/statics.ts
@@ -1,8 +1,6 @@
-import { baseUrl } from "../util/constants.ts";
-
 export const statics: Record<string, ConstructorParameters<typeof Response>> = {
   "github.svg": [
-    await fetch(`${baseUrl}/webapp/github.svg`).then((r) => r.text()),
+    await Deno.readTextFile(new URL("./github.svg", import.meta.url)),
     { headers: { "Content-Type": "image/svg+xml" } },
   ],
 };


### PR DESCRIPTION
Deno Deploy Classic is being shut down, so this migrates the app to the new [Deno Deploy](https://console.deno.com) service following the [official migration guide](https://docs.deno.com/deploy/migration_guide/).

## Changes

- **`Deno.serve()` instead of `addEventListener("fetch", …)`** — the core required runtime change. The old Deploy Classic `FetchEvent` handler is replaced with the built-in `Deno.serve()` API. Deploying the legacy handler on the new service causes warmup timeouts.
- **Filesystem reads for static assets** — `index.tsx` (style.css) and `webapp/statics.ts` (github.svg) previously fetched the deployment's own source files over HTTP via `import.meta.url`. The new service doesn't serve deployment source, so these now use `Deno.readTextFile(new URL(...))`. Removed the now-unused `util/constants.ts` `baseUrl` helper.
- **`deno.json`** — adds the JSX compiler options (migrated from `tsconfig.json`, which is removed), `dev`/`start` tasks, and the `index.tsx` deploy entrypoint so the new GitHub-integrated build / `deno deploy` CLI can detect it.
- **`dev` script** → `deno task dev` (the `deployctl` CLI is deprecated in favor of `deno deploy`).
- **Deno 2 compat** — added `override` modifiers to `BinaryHeap`'s `push`/`pop`.
- Pointed VS Code at `deno.json` and refreshed the README deploy instructions.

## Verification

Ran the migrated server locally (`deno task start`) and exercised every route:

| Route | Result |
| --- | --- |
| `GET /` | 200, SSR homepage renders |
| `POST /<slug>` | 200, stores content |
| `GET /<slug>` | 200, returns stored content |
| `GET /github.svg` | 200, `image/svg+xml` (filesystem-served) |
| `GET /<missing>` | 404 |

`deno fmt` and `deno lint` pass on the changed files.

## Notes for the maintainer

Beyond this code migration, the guide requires some dashboard steps that can't be done from the repo: create an organization at console.deno.com, connect this repo (or deploy via `deno deploy`), and re-set any environment variables. `BroadcastChannel` (used in `store.ts`) still works but is single-instance on the new service; the existing timeout fallback already handles that gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJb3Mh4Vn8TSqywPNXpn2a)_